### PR TITLE
regexturtle.sh should point to 'dist/ConsoleRegexTurtle.jar'

### DIFF
--- a/ConsoleRegexTurtle/regexturtle.sh
+++ b/ConsoleRegexTurtle/regexturtle.sh
@@ -7,4 +7,4 @@ MAXMEM=$(( MEMSYSTEM-512 ))
 XMSMEM=$(( MAXMEM/2 ))
 echo "System memory:"$MEMSYSTEM "Mbytes"
 echo "RegexTurtle is going to use this amount of the system memory:"$MAXMEM "Mbytes" 
-java -Xmx${MAXMEM}M -Xms${XMSMEM}M -jar "ConsoleRegexTurtle.jar" $@ 
+java -Xmx${MAXMEM}M -Xms${XMSMEM}M -jar "dist/ConsoleRegexTurtle.jar" "$@"


### PR DESCRIPTION
The standard ant command generates the output ConsoleRegexTurtle.jar
to dist/ConsoleRegexTurtle.jar. 'regexturtle.sh' should point directly
to this file.

Fixes #1
